### PR TITLE
Remove nonstandard typename questionmark extensions

### DIFF
--- a/hedgehog-test/Main/Gen.hs
+++ b/hedgehog-test/Main/Gen.hs
@@ -833,7 +833,7 @@ arrayDimensionsAmount = int (Range.exponential 0 4)
 
 -- ** Typename
 
-typename = Typename <$> bool <*> simpleTypename <*> pure False <*> maybe ((,) <$> typenameArrayDimensions <*> pure False)
+typename = Typename <$> bool <*> simpleTypename <*> maybe typenameArrayDimensions
 
 typenameArrayDimensions =
   choice

--- a/library/PostgresqlSyntax/Ast.hs
+++ b/library/PostgresqlSyntax/Ast.hs
@@ -1984,10 +1984,8 @@ data Typename
       Bool
       -- ^ SETOF
       SimpleTypename
-      Bool
-      -- ^ Question mark
-      (Maybe (TypenameArrayDimensions, Bool))
-      -- ^ Array dimensions possibly followed by a question mark
+      (Maybe TypenameArrayDimensions)
+      -- ^ Array dimensions
   deriving (Show, Generic, Eq, Ord)
 
 -- |

--- a/library/PostgresqlSyntax/Parsing.hs
+++ b/library/PostgresqlSyntax/Parsing.hs
@@ -2021,22 +2021,19 @@ typename =
     a <- option False (keyword "setof" *> space1 $> True)
     b <- simpleTypename
     endHead
-    c <- trueIfPresent (space *> char '?')
     asum
       [ do
           space1
           keyword "array"
           endHead
           d <- optional (space *> inBrackets iconst)
-          e <- trueIfPresent (space *> char '?')
-          return (Typename a b c (Just (ExplicitTypenameArrayDimensions d, e))),
+          return (Typename a b (Just (ExplicitTypenameArrayDimensions d))),
         do
           space
           d <- arrayBounds
           endHead
-          e <- trueIfPresent (space *> char '?')
-          return (Typename a b c (Just (BoundsTypenameArrayDimensions d, e))),
-        return (Typename a b c Nothing)
+          return (Typename a b (Just (BoundsTypenameArrayDimensions d))),
+        return (Typename a b Nothing)
       ]
 
 arrayBounds = sep1 space (inBrackets (optional iconst))

--- a/library/PostgresqlSyntax/Rendering.hs
+++ b/library/PostgresqlSyntax/Rendering.hs
@@ -857,11 +857,8 @@ anyName (AnyName a b) = colId a <> foldMap attrs b
 
 -- * Types
 
-typename (Typename a b c d) =
-  bool "" "SETOF " a <> simpleTypename b <> foldMap typenameArrayDimensionsWithQuestionMark d
-
-typenameArrayDimensionsWithQuestionMark (a, b) =
-  typenameArrayDimensions a
+typename (Typename a b c) =
+  bool "" "SETOF " a <> simpleTypename b <> foldMap typenameArrayDimensions c
 
 typenameArrayDimensions = \case
   BoundsTypenameArrayDimensions a -> arrayBounds a

--- a/tasty-test/Main.hs
+++ b/tasty-test/Main.hs
@@ -42,8 +42,6 @@ main =
                   Parsing.typename
                   [ "int4[]",
                     "int4[][]",
-                    "int4?[]",
-                    "int4?[]?",
                     "aa array",
                     "DOUBLE PRECISION",
                     "bool",


### PR DESCRIPTION
* These are used in hasql-th for type annotations.
* I plan to use a modified version of hasql-th without this feature.